### PR TITLE
compileOnly androidx.annotation dependency.

### DIFF
--- a/fancytoastlib/build.gradle
+++ b/fancytoastlib/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    compileOnly 'androidx.annotation:annotation:1.2.0'
     testImplementation 'junit:junit:4.13.2'
 }
 


### PR DESCRIPTION
To reduce the lib's size.